### PR TITLE
arch: add big endian support

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -61,6 +61,9 @@ module = MPU
 module-str = mpu
 source "subsys/logging/Kconfig.template.log_config"
 
+config BIG_ENDIAN
+       bool
+
 config HW_STACK_PROTECTION
 	bool "Hardware Stack Protection"
 	depends on ARCH_HAS_STACK_PROTECTION

--- a/include/linker/linker-tool-gcc.h
+++ b/include/linker/linker-tool-gcc.h
@@ -16,7 +16,11 @@
 #define ZEPHYR_INCLUDE_LINKER_LINKER_TOOL_GCC_H_
 
 #if defined(CONFIG_ARM)
+#if defined(CONFIG_BIG_ENDIAN)
+	OUTPUT_FORMAT("elf32-bigarm")
+#else
 	OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+#endif
 #elif defined(CONFIG_ARC)
 	OUTPUT_FORMAT("elf32-littlearc", "elf32-bigarc", "elf32-littlearc")
 #elif defined(CONFIG_X86)


### PR DESCRIPTION
This patch adds Big Endian architecture support.  Even if a compiler
generating big endian object files is used, our linker script, or
include/linker/linker-tool-gcc.h to be precise, has default output
format as little endian.

This patch adds a hidden config CONFIG_BIG_ENDIAN, which should be set
by big endian architectures or a SoC's, and adds an condition to
switch OUTPUT_FORMAT in our linker.cmd.