### PR TITLE
drivers: spi: nrfx: Fix for CONFIG_MULTITHREADING=n

### DIFF
--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -255,8 +255,10 @@ static int transceive(const struct device *dev,
 			 */
 			finish_transaction(dev, -ETIMEDOUT);
 
+#if CONFIG_MULTITHREADING
 			/* Clean up the driver state. */
 			k_sem_reset(&dev_data->ctx.sync);
+#endif
 		}
 	}
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -419,8 +419,10 @@ static int transceive(const struct device *dev,
 			 */
 			finish_transaction(dev, -ETIMEDOUT);
 
+#if CONFIG_MULTITHREADING
 			/* Clean up the driver state. */
 			k_sem_reset(&dev_data->ctx.sync);
+#endif
 #ifdef CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58
 			anomaly_58_workaround_clear(dev_data);
 #endif


### PR DESCRIPTION
The nrfx implementations directly call `k_sem_reset` on the sync-semaphore.
For `CONFIG_MULTITHREADING=n` to work, this needs to be removed.